### PR TITLE
Fix docs theme and add table of contents

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,7 +2,11 @@ title: "Curso de Python"
 remote_theme: just-the-docs/just-the-docs
 color_scheme: dark
 
-# Optional: adds the outline on the right
+heading_anchors: true
+
+# Optional: adds the outline on the right using jekyll-toc
+toc: true
+toc_levels: 1..3
 aux_links:
   "GitHub Repo":
     - "https://github.com/chrisdewa/curso_python"

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,4 +2,4 @@
 
 Estas lecturas pueden consultarse tanto en [github](https://github.com/chrisdewa/curso_python/tree/main/docs) como en la [página](https://chrisdewa.github.io/curso_python)
 
-[Tema 1: Generalidades](<Tema 1 - generalidades>)
+[Tema 1: Generalidades](tema1-generalidades)

--- a/docs/tema1-generalidades.md
+++ b/docs/tema1-generalidades.md
@@ -1,9 +1,12 @@
 ---
-title: Introducción
+title: "Tema 1: Generalidades"
 nav_order: 1
 ---
 
-# Generalidades 
+# Generalidades
+
+* TOC
+{:toc}
 
 ## Programación
 


### PR DESCRIPTION
## Summary
- rename doc to avoid spaces in URL
- update link to first lecture
- update lecture title
- enable TOC with anchors for headings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e2cf73e8483258e63e6d5529ca1aa